### PR TITLE
Use ImagePicker media type constant

### DIFF
--- a/src/screens/profile/profile-screen.tsx
+++ b/src/screens/profile/profile-screen.tsx
@@ -48,7 +48,7 @@ export function ProfileScreen() {
     try {
       setIsPickingImage(true);
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ['images'],
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
         allowsEditing: true,
         aspect: [1, 1],
         quality: 0.7,


### PR DESCRIPTION
## Summary
- replace the string-based mediaTypes value with Expo's ImagePicker.MediaTypeOptions.Images constant when launching the image picker

## Testing
- not run (simulators for iOS and Android are unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cfc181e4d4832f82b6d1172abf0307