### PR TITLE
Fix Ionicons color for fallback chat avatar

### DIFF
--- a/src/screens/messages/chat-screen.tsx
+++ b/src/screens/messages/chat-screen.tsx
@@ -337,7 +337,7 @@ export function ChatScreen() {
               />
             ) : (
               <View style={[styles.avatar, { backgroundColor: getAvatarColor(item.sender_username) }]}>
-                <Ionicons name="person" size={20} color="#00000" />
+                <Ionicons name="person" size={20} color="#000000" />
               </View>
             )}
           </View>


### PR DESCRIPTION
## Summary
- update the fallback chat avatar icon color to use a valid hex value so React Native no longer warns about the color prop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfc17e5f14832f87ec2db54e27b9ba