### PR TITLE
Optimize liked post lookup in feed screen

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -527,4 +527,19 @@ export const dbOperations = {
       ORDER BY m.created_at ASC
     `, [userId1, userId2, userId2, userId1]);
   }
-}; 
+};
+
+export async function getLikedPostIds(userId: string, postIds: string[]): Promise<string[]> {
+  if (postIds.length === 0) {
+    return [];
+  }
+
+  const db = await getDatabase();
+  const placeholders = postIds.map(() => '?').join(', ');
+  const rows = await db.getAllAsync<{ post_id: string }>(
+    `SELECT post_id FROM likes WHERE user_id = ? AND post_id IN (${placeholders})`,
+    [userId, ...postIds]
+  );
+
+  return rows.map(row => row.post_id);
+}


### PR DESCRIPTION
## Summary
- add a database helper to fetch liked post IDs for a user in a single query
- update the feed screen to use the batch lookup instead of sequential like checks for each post

## Testing
- npx tsc --noEmit *(fails: Option 'customConditions' can only be used when 'moduleResolution' is set to 'node16', 'nodenext', or 'bundler')*

------
https://chatgpt.com/codex/tasks/task_e_68cfc1760b60832faf3be0421710595f